### PR TITLE
fix: dapp connect

### DIFF
--- a/app/database/DappDatabase.ts
+++ b/app/database/DappDatabase.ts
@@ -47,6 +47,20 @@ export class DappDatabase extends Dexie {
       aleo_connect_history: null,
     });
 
+    this.version(5).upgrade(async (tx) => {
+      await tx
+        .table("dapp_history")
+        .filter((history: Partial<ConnectHistory>) => !history.coinType)
+        .modify((history: Partial<ConnectHistory>) => {
+          history.coinType = history.address?.startsWith("aleo1")
+            ? CoinType.ALEO
+            : CoinType.ETH;
+          if (history.coinType === CoinType.ETH && !history.network) {
+            history.network = "";
+          }
+        });
+    });
+
     this.dapp_history = this.table("dapp_history");
     this.request = this.table("request");
   }

--- a/app/database/DappDatabase.ts
+++ b/app/database/DappDatabase.ts
@@ -7,11 +7,6 @@ import {
 import { CoinType } from "core/types";
 
 export class DappDatabase extends Dexie {
-  /**
-   * @deprecated
-   */
-  aleo_history: Dexie.Table<AleoConnectHistory, string>;
-
   dapp_history: Dexie.Table<ConnectHistory, string>;
   request: Dexie.Table<DappRequest, string>;
 
@@ -31,16 +26,21 @@ export class DappDatabase extends Dexie {
       .stores({
         dapp_history: "++id, [address+coinType+network], site.origin",
       })
-      .upgrade(async (tx) =>
-        // TODO check this
-        this.aleo_history.each(
-          async (aleoHistory) =>
-            this.dapp_history?.add({
-              ...aleoHistory,
-              coinType: CoinType.ALEO,
-            }),
-        ),
-      );
+      .upgrade(async (tx) => {
+        const aleoHistories = (await tx
+          .table("aleo_history")
+          .toArray()) as AleoConnectHistory[];
+        if (!aleoHistories.length) {
+          return;
+        }
+
+        await tx.table("dapp_history").bulkAdd(
+          aleoHistories.map((aleoHistory) => ({
+            ...aleoHistory,
+            coinType: CoinType.ALEO,
+          })),
+        );
+      });
 
     this.version(4).stores({
       aleo_history: null,


### PR DESCRIPTION
修复了app升级时,老版本dapp连接历史数据库的bug(migration时没有赋值)

## Summary by Sourcery

Fix migration of legacy dapp connection history when upgrading the local Dapp database.

Bug Fixes:
- Ensure Aleo dapp connection history is correctly migrated into the unified dapp history table during database upgrades, preventing loss of old connection records.

Enhancements:
- Remove the deprecated Aleo-specific history table property from the DappDatabase definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated local history structure and cleaned up related declarations.
  * Improved migration logic to preserve existing history during updates and ensure records are correctly categorized to maintain continuity for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->