### PR TITLE
fix: stabilize Chrome popup dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FoxWallet</title>
+    <!--
+      Chrome may measure an extension popup before the module stylesheet loads
+      and React mounts. Keep these values in sync with POPUP_WIDTH/POPUP_HEIGHT.
+    -->
+    <style>
+      html,
+      body {
+        margin: 0;
+        min-width: 380px;
+        min-height: 600px;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- set critical popup dimensions before module CSS and React load
- prevent Chrome from sizing the initial popup around the 40px loading spinner
- retain responsive sizing when the extension page is opened in a normal tab

## Verification
- yarn vite build --mode development
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Set minimum popup dimensions to 380×600 pixels for a more consistent display.
  * Added documentation explaining the dimension settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->